### PR TITLE
fixing show for ratios 

### DIFF
--- a/theory/AetherlingSTIR/src/lib/STMetrics.hs
+++ b/theory/AetherlingSTIR/src/lib/STMetrics.hs
@@ -48,7 +48,7 @@ data SteadyStateAndWarmupRatio = SWRatio {swNumerator :: SteadyStateAndWarmupLen
 instance Show SteadyStateAndWarmupRatio where
   show (SWRatio num denom) | num == denom = "1"
   show (SWRatio (SWLen numMult numWarmup) (SWLen denomMult denomWarmup)) | numWarmup == 0 &&
-    denomWarmup == 0 = show (SWLen (numMult `ceilDiv` denomMult) 0)
+    denomWarmup == 0 = "(" ++ show numMult ++ "/" ++ show denomMult ++ ")"
   show (SWRatio num denom) = "(" ++ show num ++ ") / (" ++ show denom ++ ")"
 
 data PortThroughput = PortThroughput {throughputType :: TokenType, throughputClocks :: SteadyStateAndWarmupRatio}


### PR DESCRIPTION
This is in case where warmups are not 0 for at least 1 and num and denom not equal